### PR TITLE
Add getItemKey

### DIFF
--- a/database/src/main/java/com/firebase/ui/database/FirebaseListAdapter.java
+++ b/database/src/main/java/com/firebase/ui/database/FirebaseListAdapter.java
@@ -127,6 +127,12 @@ public abstract class FirebaseListAdapter<T> extends BaseAdapter {
         // http://stackoverflow.com/questions/5100071/whats-the-purpose-of-item-ids-in-android-listview-adapter
         return mSnapshots.getItem(i).getKey().hashCode();
     }
+    
+    // get the key of the node. 
+    public String getItemKey(int i) {
+        return mSnapshots.getItem(i).getKey();
+    }
+    
 
     @Override
     public View getView(int position, View view, ViewGroup viewGroup) {

--- a/database/src/main/java/com/firebase/ui/database/FirebaseRecyclerAdapter.java
+++ b/database/src/main/java/com/firebase/ui/database/FirebaseRecyclerAdapter.java
@@ -162,6 +162,11 @@ public abstract class FirebaseRecyclerAdapter<T, VH extends RecyclerView.ViewHol
         return mSnapshots.getItem(position).getKey().hashCode();
     }
 
+    public long getItemId(int i) {
+        // http://stackoverflow.com/questions/5100071/whats-the-purpose-of-item-ids-in-android-listview-adapter
+        return mSnapshots.getItem(i).getKey().hashCode();
+    }
+    
     @Override
     public VH onCreateViewHolder(ViewGroup parent, int viewType) {
         ViewGroup view = (ViewGroup) LayoutInflater.from(parent.getContext()).inflate(viewType, parent, false);


### PR DESCRIPTION
There is getItemId which is doing the getItemKey operation but not expose the key actually.
It's very helpful to make the ViewHolder.
Most of time, Saving the key inside the node can make the key easily be get in the ViewHolder. But sometime, node will be update very frequently that I have to save key so many times or check if the key existed too much. So get the key while display the adapter is better.
And when I pull this request, I have a great question. THERE is a getItemId, why not a getItemKey ? 
